### PR TITLE
fix: fix template match regexp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ module.exports = {
       let _package = getPackage(PATH.dirname(page.rawPath));
 
       let paramRegExp = /([^=]+)=['"]([^'"]+)['"]/i;
-      let blockRegExp = /{%\s+templateblock\s+([^}]+)%}([^{]+){%\s+endtemplateblock\s+%}/ig;
+      let blockRegExp = /{%\s+templateblock\s+([^}]+)%}((.|\n)+?){%\s+endtemplateblock\s+%}/ig;
       let blocks = page.content.match(blockRegExp);
       if (blocks) {
         for (let block of blocks) {


### PR DESCRIPTION
Now the whole page generation breaks if there is "{" sign inside the page.
Containing the next example of text inside MD file will lead to white page on gitbook start:

```
{% templateblock %}

Some text

```html
  <html lang="en">
    <head>
      <meta charset="UTF-8" />
      <meta name="viewport" content="width=device-width, initial-scale=1" />
      <title>Example</title>
    </head>

    <body>
      <script>
        () => { console.log("I will not be rendered into the doc page"); }
      </script>
    </body>
  </html>
``

{% endtemplateblock %}
```